### PR TITLE
Attach elements outside the transclusionFn.

### DIFF
--- a/src/multi-transclude.js
+++ b/src/multi-transclude.js
@@ -87,18 +87,15 @@
           // the already-linked clone on the controller so that
           // it can be referenced by all relevant instances of
           // the `ng-multi-transclude` directive.
-          if(ctrl.ngMultiTransclude){
-            attach(ctrl.ngMultiTransclude);
-          }
-          else {
+          if(!ctrl.ngMultiTransclude) {
             transcludeFn(function(clone){
               ctrl.ngMultiTransclude = clone;
-              attach(clone);
               scope.$on('$destroy', function() {
                 clone.remove();
               });
             });
           }
+          attach(ctrl.ngMultiTransclude);
         }
       };
     }


### PR DESCRIPTION
DOM should be manipulated outside the transcludeFn, otherwise ng-click and other directives that are connected to outher scope won't work. For example:

<test>
    <div name="trans1">
        <button ng-click="button1()">button1</button>
    </div>

```
<div name="trans2">
    <button ng-click="button2()">button2</button>
</div>

<div name="trans3">
    <button ng-click="button3()">button3</button>
</div>
```

</test>

The first button won't respond to ng-click.
