### PR TITLE
Fix prototypical inheritance

### DIFF
--- a/src/multi-transclude.js
+++ b/src/multi-transclude.js
@@ -57,8 +57,7 @@
 
     // Transclude content and keep track of it; be sure to keep it in the DOM
     // by attaching it to `$element`.
-    var childScope = $scope.$new();
-    $transclude(childScope, function(clone){
+    $transclude(function(clone){
       toTransclude = clone;
 
       transcludeContainer.append(clone);


### PR DESCRIPTION
Not adding a new `childScope` solves the problem of the lost prototypical inheritance described in #23.