### PR TITLE
Fix for example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ to "wrap" all instances of `ng-multi-transclude` in your template:
   app.directive('ngAnotherDirective', function(){
     return {
       templateUrl: 'another-template',
+      transclude: true,
       link: function(scope, element, attrs){
         // Some fancy logic.
       }


### PR DESCRIPTION
For ng-multi-transclude to work the top level directive must do a transclude. This is not reflected in the example code shown in the README.md
